### PR TITLE
Parse custom zone mapping information

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -223,7 +223,7 @@ func getExoscaleNodeMetadata() (*nodeMetadata, error) {
 		return nil, fmt.Errorf("node meta data Instance ID %s: %w", node.Spec.ProviderID, err)
 	}
 
-	zonesToURL := map[string]v3.URL{}
+	var zonesToURL map[string]v3.URL
 
 	customZonesStr := os.Getenv("ZONE_TO_URL")
 	if customZonesStr != "" {


### PR DESCRIPTION
If `ZONE_TO_URL` is present in the environment, parse its JSON contents as `string->v3.URL`

