### PR TITLE
Renaming on ENV and secret name

### DIFF
--- a/cmd/exoscale-csi-driver/main.go
+++ b/cmd/exoscale-csi-driver/main.go
@@ -43,7 +43,8 @@ func main() {
 
 	apiKey := os.Getenv("EXOSCALE_API_KEY")
 	apiSecret := os.Getenv("EXOSCALE_API_SECRET")
-	apiURL := os.Getenv("EXOSCALE_API_URL")
+	// Mostly for internal use.
+	apiURL := os.Getenv("EXOSCALE_API_ENDPOINT")
 
 	// The node mode don't need secrets and do not interact with Exoscale API.
 	if *mode != string(driver.NodeMode) && (apiKey == "" || apiSecret == "") {

--- a/deployment/exoscale-csi.yaml
+++ b/deployment/exoscale-csi.yaml
@@ -848,7 +848,7 @@ spec:
                   fieldPath: metadata.name
           envFrom:
             - secretRef:
-                name: exoscale-csi-credentials
+                name: exoscale-credentials
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/

--- a/deployment/exoscale-secret.sh
+++ b/deployment/exoscale-secret.sh
@@ -4,7 +4,7 @@ cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: Secret
 metadata:
-  name: exoscale-csi-credentials
+  name: exoscale-credentials
   namespace: kube-system
 type: Opaque
 data:

--- a/deployment/exoscale-secret.yaml
+++ b/deployment/exoscale-secret.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: exoscale-csi-credentials
+  name: exoscale-credentials
   namespace: kube-system
 type: Opaque
 stringData:

--- a/internal/integ/k8s/k8s.go
+++ b/internal/integ/k8s/k8s.go
@@ -268,7 +268,7 @@ func (k *K8S) applyManifest(ctx context.Context, manifest []byte) error {
 
 // ApplySecret creates the secret needed for the CSI to work if it doesn't exist already.
 func (k *K8S) ApplySecret(ctx context.Context, apiKey, apiSecret string) error {
-	name := "exoscale-csi-credentials"
+	name := "exoscale-credentials"
 	namespace := "kube-system"
 
 	secretData := map[string][]byte{


### PR DESCRIPTION
# Description
Rename `EXOSCALE_API_URL` to `EXOSCALE_API_ENDPOINT`
Rename `exoscale-csi-credentials` to `exoscale-credentials`

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Integration tests OK


fix #6 

