### PR TITLE
Project Status: beta phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Project Status: beta phase (#10)
 * Remove multizone and fix URL environment (#4)
 
 ## 0.29.0

--- a/README.md
+++ b/README.md
@@ -73,4 +73,4 @@ For example, CSI `0.99` would be compatible with Kubernetes versions `1.99`, `1.
 
 ## Project status
 
-We consider the CSI to be in Beta phase. Although it reliably performs it's essential functions, missing features and bugs have to be expected.
+We consider the CSI to be in Beta phase. Although it reliably performs its essential functions, missing features and bugs have to be expected.

--- a/README.md
+++ b/README.md
@@ -71,3 +71,6 @@ For example, CSI `0.99` would be compatible with Kubernetes versions `1.99`, `1.
 |-------------|-------------------------------|
 | 0.29        | 1.29, 1.28, 1.27              |
 
+## Project status
+
+We consider the CSI to be in Beta phase. Although it reliably performs it's essential functions, missing features and bugs have to be expected.


### PR DESCRIPTION
# Description

We add a project status section to the README notifying users that the CSI is considered to be in beta phase.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Integration tests OK

## Testing


