### PR TITLE
controller: fix frequent sidecar restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug fixes
+* controller: fix frequent sidecar restarts #12 
+
+### Improvements
 * split deployment manifests (#11) 
 * Project Status: beta phase (#10)
 * Remove multizone and fix URL environment (#4)

--- a/deployment/controller-rbac.yaml
+++ b/deployment/controller-rbac.yaml
@@ -11,7 +11,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "delete"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "list", "watch"]
@@ -35,7 +35,7 @@ rules:
     verbs: ["get", "list", "watch", "update", "create", "patch"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
-    verbs: ["get", "watch", "list", "delete", "update", "create"]
+    verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -98,6 +98,9 @@ rules:
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions", "leases"]
     verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -123,6 +126,9 @@ rules:
   - apiGroups: [""]
     resources: ["pods", "events"]
     verbs: ["get", "watch", "list"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deployment/controller-rbac.yaml
+++ b/deployment/controller-rbac.yaml
@@ -33,6 +33,9 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots", "volumesnapshots/status", "volumesnapshotclasses", "volumesnapshotcontents", "volumesnapshotcontents/status"]
     verbs: ["get", "list", "watch", "update", "create", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -93,7 +96,10 @@ rules:
     resources: ["volumesnapshots", "volumesnapshots/status", "volumesnapshotclasses", "volumesnapshotcontents"]
     verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
   - apiGroups: ["apiextensions.k8s.io"]
-    resources: ["customresourcedefinitions"]
+    resources: ["customresourcedefinitions", "leases"]
+    verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
     verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
 ---
 kind: ClusterRoleBinding
@@ -120,6 +126,9 @@ rules:
   - apiGroups: [""]
     resources: ["pods", "events"]
     verbs: ["get", "watch", "list"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deployment/controller-rbac.yaml
+++ b/deployment/controller-rbac.yaml
@@ -33,9 +33,6 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots", "volumesnapshots/status", "volumesnapshotclasses", "volumesnapshotcontents", "volumesnapshotcontents/status"]
     verbs: ["get", "list", "watch", "update", "create", "patch"]
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
-    verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -96,10 +93,7 @@ rules:
     resources: ["volumesnapshots", "volumesnapshots/status", "volumesnapshotclasses", "volumesnapshotcontents"]
     verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
   - apiGroups: ["apiextensions.k8s.io"]
-    resources: ["customresourcedefinitions", "leases"]
-    verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
+    resources: ["customresourcedefinitions"]
     verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
 ---
 kind: ClusterRoleBinding
@@ -126,9 +120,6 @@ rules:
   - apiGroups: [""]
     resources: ["pods", "events"]
     verbs: ["get", "watch", "list"]
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
-    verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deployment/controller.yaml
+++ b/deployment/controller.yaml
@@ -66,6 +66,9 @@ spec:
             - "--v=5"
             - "--csi-address=$(CSI_ADDRESS)"
             - "--leader-election"
+            - "--leader-election-lease-duration=60s"
+            - "--leader-election-renew-deadline=40s"
+            - "--leader-election-retry-period=20s"
             - "--feature-gates=Topology=true"
             - "--default-fstype=ext4"
           env:
@@ -87,6 +90,9 @@ spec:
             - "--v=5"
             - "--csi-address=$(CSI_ADDRESS)"
             - "--leader-election"
+            - "--leader-election-lease-duration=60s"
+            - "--leader-election-renew-deadline=40s"
+            - "--leader-election-retry-period=20s"
           env:
             - name: CSI_ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -106,6 +112,9 @@ spec:
             - "--v=5"
             - "--csi-address=$(CSI_ADDRESS)"
             - "--leader-election"
+            - "--leader-election-lease-duration=60s"
+            - "--leader-election-renew-deadline=40s"
+            - "--leader-election-retry-period=20s"
           env:
             - name: CSI_ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -124,6 +133,9 @@ spec:
           args:
             - "--v=5"
             - "--leader-election"
+            - "--leader-election-lease-duration=60s"
+            - "--leader-election-renew-deadline=40s"
+            - "--leader-election-retry-period=20s"
           resources:
             limits:
               cpu: 400m
@@ -137,6 +149,9 @@ spec:
             - "--v=5"
             - "--csi-address=$(CSI_ADDRESS)"
             - "--leader-election"
+            - "--leader-election-lease-duration=60s"
+            - "--leader-election-renew-deadline=40s"
+            - "--leader-election-retry-period=20s"
           env:
             - name: CSI_ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/deployment/controller.yaml
+++ b/deployment/controller.yaml
@@ -66,9 +66,9 @@ spec:
             - "--v=5"
             - "--csi-address=$(CSI_ADDRESS)"
             - "--leader-election"
-            - "--leader-election-lease-duration=60s"
-            - "--leader-election-renew-deadline=40s"
-            - "--leader-election-retry-period=20s"
+            - "--leader-election-lease-duration=30s"
+            - "--leader-election-renew-deadline=20s"
+            - "--leader-election-retry-period=10s"
             - "--feature-gates=Topology=true"
             - "--default-fstype=ext4"
           env:
@@ -90,9 +90,9 @@ spec:
             - "--v=5"
             - "--csi-address=$(CSI_ADDRESS)"
             - "--leader-election"
-            - "--leader-election-lease-duration=60s"
-            - "--leader-election-renew-deadline=40s"
-            - "--leader-election-retry-period=20s"
+            - "--leader-election-lease-duration=30s"
+            - "--leader-election-renew-deadline=20s"
+            - "--leader-election-retry-period=10s"
           env:
             - name: CSI_ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -112,9 +112,9 @@ spec:
             - "--v=5"
             - "--csi-address=$(CSI_ADDRESS)"
             - "--leader-election"
-            - "--leader-election-lease-duration=60s"
-            - "--leader-election-renew-deadline=40s"
-            - "--leader-election-retry-period=20s"
+            - "--leader-election-lease-duration=30s"
+            - "--leader-election-renew-deadline=20s"
+            - "--leader-election-retry-period=10s"
           env:
             - name: CSI_ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -133,9 +133,9 @@ spec:
           args:
             - "--v=5"
             - "--leader-election"
-            - "--leader-election-lease-duration=60s"
-            - "--leader-election-renew-deadline=40s"
-            - "--leader-election-retry-period=20s"
+            - "--leader-election-lease-duration=30s"
+            - "--leader-election-renew-deadline=20s"
+            - "--leader-election-retry-period=10s"
           resources:
             limits:
               cpu: 400m
@@ -149,9 +149,9 @@ spec:
             - "--v=5"
             - "--csi-address=$(CSI_ADDRESS)"
             - "--leader-election"
-            - "--leader-election-lease-duration=60s"
-            - "--leader-election-renew-deadline=40s"
-            - "--leader-election-retry-period=20s"
+            - "--leader-election-lease-duration=30s"
+            - "--leader-election-renew-deadline=20s"
+            - "--leader-election-retry-period=10s"
           env:
             - name: CSI_ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/internal/integ/cluster/setup.go
+++ b/internal/integ/cluster/setup.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"time"
 
 	"github.com/exoscale/exoscale/csi-driver/internal/integ/flags"
 
@@ -149,6 +150,10 @@ func Setup() error {
 			return fmt.Errorf("error applying CSI: %w", err)
 		}
 	}
+
+	// give the CSI some time to become ready
+	// TODO find a more appropriate way to do this.
+	time.Sleep(30 * time.Second)
 
 	return nil
 }

--- a/internal/integ/integ_test.go
+++ b/internal/integ/integ_test.go
@@ -25,6 +25,8 @@ func TestMain(m *testing.M) {
 		exitCode = 1
 	}
 
+	time.Sleep(time.Minute)
+
 	if err == nil {
 		exitCode = m.Run()
 	}

--- a/internal/integ/integ_test.go
+++ b/internal/integ/integ_test.go
@@ -25,8 +25,6 @@ func TestMain(m *testing.M) {
 		exitCode = 1
 	}
 
-	time.Sleep(time.Minute)
-
 	if err == nil {
 		exitCode = m.Run()
 	}
@@ -65,7 +63,7 @@ func awaitExpectation(t *testing.T, expected interface{}, get getFunc) {
 	for i := 0; i < 10; i++ {
 		actual = get()
 
-		time.Sleep(5 * time.Second)
+		time.Sleep(10 * time.Second)
 
 		if assert.ObjectsAreEqualValues(expected, actual) {
 			break


### PR DESCRIPTION
# Description
Containers in the controller pod would frequently restart
```shell
❯ kubectl -n kube-system get pods | grep exoscale-csi
exoscale-csi-controller-67c9d7ddb-2hgtv    7/7     Running   35 (89m ago)    6d19h
exoscale-csi-controller-67c9d7ddb-78744    7/7     Running   41 (5h6m ago)   6d19h
exoscale-csi-node-fvr62                    3/3     Running   0               6d19h
exoscale-csi-node-lsx6b                    3/3     Running   0               6d19h
```
Upon closer inspection we found that only sidecar containers would restart with the same errors at roughly the same time:
```
I0215 11:52:04.337536       1 leaderelection.go:281] successfully renewed lease kube-system/external-resizer-csi-exoscale-com
E0215 11:52:16.353119       1 leaderelection.go:369] Failed to update lock: etcdserver: request timed out
I0215 11:52:19.341615       1 leaderelection.go:285] failed to renew lease kube-system/external-resizer-csi-exoscale-com: timed out waiting for the condition
F0215 11:52:19.341778       1 leader_election.go:182] stopped leading
```

Judging by apiserver logs it looks like etcd throttled the requests because they were too frequent, which led the sidecars to restart. To fix this we double the lease durations, renew deadlines and retry periods for the leader elections of all sidecars.
We also add some missing RBAC rules.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Integration tests OK

## Testing
The sidecars have been running for more than two days without restarting, which was the case previously.
```shell
❯ kubectl -n kube-system get pods | grep exoscale-csi
exoscale-csi-controller-6d55bf4879-4wjl7   7/7     Running   0          2d17h
exoscale-csi-controller-6d55bf4879-tvb9t   7/7     Running   0          2d17h
exoscale-csi-node-fvr62                    3/3     Running   0          10d
exoscale-csi-node-lsx6b                    3/3     Running   0          10d
```

I also checked the logs of all the sidecars and couldn't find anymore errors.