### PR TITLE
integ-tests: use IAMv3 API key

### DIFF
--- a/.github/workflows/integ-tests.yml
+++ b/.github/workflows/integ-tests.yml
@@ -44,8 +44,6 @@ jobs:
             --create-cluster \
             --create-csi-secret \
             --tear-down-csi \
-            --tear-down-cluster \
-            -run '^$' \
             --image exoscale/csi-driver-integ-test:csi-pr-integ-test \
             --cluster-name csi-pr-integ-test \
             --zone ch-gva-2

--- a/.github/workflows/integ-tests.yml
+++ b/.github/workflows/integ-tests.yml
@@ -44,6 +44,8 @@ jobs:
             --create-cluster \
             --create-csi-secret \
             --tear-down-csi \
+            --tear-down-cluster \
+            -run '^$' \
             --image exoscale/csi-driver-integ-test:csi-pr-integ-test \
             --cluster-name csi-pr-integ-test \
             --zone ch-gva-2

--- a/.github/workflows/integ-tests.yml
+++ b/.github/workflows/integ-tests.yml
@@ -44,12 +44,10 @@ jobs:
             --create-cluster \
             --create-csi-secret \
             --tear-down-csi \
-            --tear-down-cluster \
-            -run '^$' \
             --image exoscale/csi-driver-integ-test:csi-pr-integ-test \
             --cluster-name csi-pr-integ-test \
             --zone ch-gva-2
         shell: bash
         env:
-          EXOSCALE_API_KEY: ${{ secrets.EXOSCALE_API_KEY }}
-          EXOSCALE_API_SECRET: ${{ secrets.EXOSCALE_API_SECRET }}
+          EXOSCALE_API_KEY: ${{ secrets.EXOSCALE_API_KEY_IAMV3 }}
+          EXOSCALE_API_SECRET: ${{ secrets.EXOSCALE_API_SECRET_IAMV3 }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+* integ-tests: use IAMv3 API key #13 
+
 ## 0.29.2
 
 ### Bug fixes

--- a/internal/integ/cluster/setup.go
+++ b/internal/integ/cluster/setup.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"time"
 
 	"github.com/exoscale/exoscale/csi-driver/internal/integ/flags"
 
@@ -160,10 +159,6 @@ func Setup() error {
 			return fmt.Errorf("error applying CSI: %w", err)
 		}
 	}
-
-	// give the CSI some time to become ready
-	// TODO find a more appropriate way to do this.
-	time.Sleep(30 * time.Second)
 
 	return nil
 }

--- a/internal/integ/cluster/setup.go
+++ b/internal/integ/cluster/setup.go
@@ -145,6 +145,16 @@ func Setup() error {
 		return err
 	}
 
+	calicoControllerName := "calico-kube-controllers"
+	if err := testCluster.awaitDeploymentReadiness(calicoControllerName); err != nil {
+		slog.Warn("error while awaiting", "deployment", calicoControllerName, "error", err)
+	}
+
+	calicoNodeName := "calico-node"
+	if err := testCluster.awaitDaemonSetReadiness(calicoNodeName); err != nil {
+		slog.Warn("error while awaiting", "DaemonSet", calicoNodeName, "error", err)
+	}
+
 	if !*flags.DontApplyCSI {
 		if err := testCluster.applyCSI(); err != nil {
 			return fmt.Errorf("error applying CSI: %w", err)

--- a/internal/integ/cluster/teardown.go
+++ b/internal/integ/cluster/teardown.go
@@ -51,14 +51,18 @@ func (c *Cluster) tearDownCSI() error {
 	for _, manifestPath := range allManifests {
 		err := c.K8s.DeleteManifest(c.exoV2Context, manifestDir+manifestPath)
 		if err != nil {
-			slog.Error("failed to delete manifest", "manifest", manifestPath)
+			slog.Error("failed to delete manifest", "manifest", manifestPath, "err", err)
 
-			finalErr = fmt.Errorf("errors while deleting manifests")
+			finalErr = fmt.Errorf("errors while deleting manifests: %w", err)
 		}
 	}
 
-	return finalErr
+	err := c.deleteAPIKeyAndRole()
+	if err != nil {
+		slog.Error("failed to clean up CSI API key and role", "err", err)
 
-	// TODO (sauterp) reenable once we have a non-legacy key in GH
-	// return c.deleteAPIKeyAndRole()
+		finalErr = fmt.Errorf("errors while cleaning up CSI API key and role: %w", err)
+	}
+
+	return finalErr
 }

--- a/internal/integ/cluster/utils.go
+++ b/internal/integ/cluster/utils.go
@@ -318,7 +318,7 @@ func (c *Cluster) awaitDeploymentReadiness(deploymentName string) error {
 
 		// check if deployment is ready
 		if deployment.Status.ReadyReplicas == *deployment.Spec.Replicas {
-			slog.Info("deployment %q is ready", deploymentName)
+			slog.Info("ready", "deployment", deploymentName)
 
 			return nil
 		}
@@ -337,7 +337,7 @@ func (c *Cluster) awaitDaemonSetReadiness(name string) error {
 
 		// check if DaemonSet is ready
 		if daemonSet.Status.DesiredNumberScheduled == daemonSet.Status.CurrentNumberScheduled {
-			slog.Info("DaemonSet %q is ready", name)
+			slog.Info("ready", "DaemonSet", name)
 
 			return nil
 		}

--- a/internal/integ/integ_test.go
+++ b/internal/integ/integ_test.go
@@ -1,6 +1,7 @@
 package integ
 
 import (
+	"flag"
 	"fmt"
 	"log/slog"
 	"os"
@@ -17,9 +18,17 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	// cluster creation takes a while so we increase the test timeout
+	// This call has to happen before testing.M.Run as that's where
+	// the flag `test.timeout` is used.
+	err := flag.Set("test.timeout", "30m")
+	if err != nil {
+		slog.Warn("failed to set test timeout", "error", err)
+	}
+
 	exitCode := 0
 
-	err := cluster.Setup()
+	err = cluster.Setup()
 	if err != nil {
 		slog.Error("error during setup", "err", err)
 		exitCode = 1

--- a/internal/integ/k8s/k8s.go
+++ b/internal/integ/k8s/k8s.go
@@ -44,6 +44,11 @@ func CreateClients(kubeconfig []byte) (*K8S, error) {
 		return nil, err
 	}
 
+	// we frequently encounter rate limiting from the test cluster
+	// to avoid this we set low values.
+	config.QPS = 1
+	config.Burst = 2
+
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Description
We use an IAMv3 key to create the test cluster and the key for the CSI secret. After each test we clean up the role and key that was created, if the CSI is torn down.

We also extend the timeout of the tests so that it has enough time to create the cluster if it does not exist yet.

To make the tests more reliable we wait for Calico and the CSI workloads to become ready and reduce the amount of requests to avoid rate limiting.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Integration tests OK

## Testing
The cluster has been torn down and re-created by the CI several times during the commits in this PR.

