### PR TITLE
go.mk: remove submodule and initialize through make

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -6,7 +6,7 @@ runs:
       with:
         fetch-depth: 0
 
-    - run: git submodule update --init --recursive go.mk
+    - run: make go.mk
       shell: bash
     - uses: ./go.mk/.github/actions/setup
 

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -18,7 +18,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v3
-      - run: git submodule update --init --recursive go.mk
+      - run: make go.mk
       - uses: ./go.mk/.github/actions/setup
       - name: Build Docker image
         run: make docker

--- a/.github/workflows/integ-tests.yml
+++ b/.github/workflows/integ-tests.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - run: git submodule update --init --recursive go.mk
+      - run: make go.mk
 
       - uses: ./go.mk/.github/actions/setup
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: git submodule update --init --recursive go.mk
+      - run: make go.mk
       - uses: ./go.mk/.github/actions/setup
       - name: Build Docker image
         run: make docker

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+/go.mk
 
 # Go workspace file
 go.work

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "go.mk"]
-	path = go.mk
-	url = https://github.com/exoscale/go.mk.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Improvements
 
+* go.mk: remove submodule and initialize through make #15
 * integ-tests: use IAMv3 API key #13 
 
 ## 0.29.2

--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,42 @@ EXTRA_ARGS := -parallel 3 -count=1 -failfast
 # Dependencies
 
 # Requires: https://github.com/exoscale/go.mk
-# - install: git submodule update --init --recursive go.mk
-# - update:  git submodule update --remote
+GO_MK_REF := v1.0.0
+
+# make go.mk a dependency for all targets
+.EXTRA_PREREQS = go.mk
+
+ifndef MAKE_RESTARTS
+# This section will be processed the first time that make reads this file.
+
+# This causes make to re-read the Makefile and all included
+# makefiles after go.mk has been cloned.
+Makefile:
+	@touch Makefile
+endif
+
+.PHONY: go.mk
+.ONESHELL:
+go.mk:
+	@if [ ! -d "go.mk" ]; then
+		git clone https://github.com/exoscale/go.mk.git
+	fi
+	@cd go.mk
+	@if ! git show-ref --quiet --verify "refs/heads/${GO_MK_REF}"; then
+		git fetch
+	fi
+	@if ! git show-ref --quiet --verify "refs/tags/${GO_MK_REF}"; then
+		git fetch --tags
+	fi
+	git checkout --quiet ${GO_MK_REF}
+
+go.mk/init.mk:
 include go.mk/init.mk
+go.mk/public.mk:
 include go.mk/public.mk
 
 ## Targets
 
 # Docker
+go.mk/init.mk:
 include Makefile.docker

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -1,3 +1,4 @@
+go.mk/version.mk:
 include go.mk/version.mk
 
 .PHONY: docker


### PR DESCRIPTION
## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Integration tests OK

## Testing
```shell
❯ make build
Cloning into 'go.mk'...
remote: Enumerating objects: 311, done.
remote: Counting objects: 100% (197/197), done.
remote: Compressing objects: 100% (95/95), done.
remote: Total 311 (delta 132), reused 138 (delta 93), pack-reused 114
Receiving objects: 100% (311/311), 62.32 KiB | 1.00 MiB/s, done.
Resolving deltas: 100% (175/175), done.
go.mk/version.mk:13: warning: overriding recipe for target 'get-version-tag'
/home/sauterp/src/github.com/exoscale/exoscale-csi-driver/go.mk/version.mk:13: warning: ignoring old recipe for target 'get-version-tag'
mkdir -p '/home/sauterp/src/github.com/exoscale/exoscale-csi-driver/bin'
'/home/sauterp/bin/go' build \
   \
  -ldflags "-X main.commit=733630e -X main.branch=philippsauter/sc-88913/go-mk-provide-alternative-to-submodule-approach -X main.buildDate=2024-02-23T10:23:46+0000 -X main.version=dev " \
   \
  -o '/home/sauterp/src/github.com/exoscale/exoscale-csi-driver/bin/' \
  './cmd/exoscale-csi-driver'
go: downloading github.com/exoscale/egoscale v0.102.4-0.20240222153804-ec94e9697218
```

