### PR TITLE
node driver: remove maxVolumesPerNode constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * go.mk: remove submodule and initialize through make #15
 * integ-tests: use IAMv3 API key #13 
+* node driver: remove maxVolumesPerNode constant #18 
 
 ## 0.29.2
 

--- a/driver/node.go
+++ b/driver/node.go
@@ -14,11 +14,6 @@ import (
 	"k8s.io/klog/v2"
 )
 
-const (
-	// TODO: replace it to get from Exoscale account resource limit.
-	maxVolumesPerNode = 5
-)
-
 type nodeService struct {
 	nodeID    v3.UUID
 	zoneName  v3.ZoneName
@@ -414,8 +409,6 @@ func (d *nodeService) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoReque
 	return &csi.NodeGetInfoResponse{
 		// Store the zone and the instanceID to let the CSI controller know the zone of the node.
 		NodeId: exoscaleID(d.zoneName, d.nodeID),
-		// TODO Will depend on Exoscale account limit, (remove const)
-		MaxVolumesPerNode: maxVolumesPerNode,
 		// newZoneTopology returns always len(1).
 		AccessibleTopology: newZoneTopology(d.zoneName)[0],
 	}, nil


### PR DESCRIPTION
## Description

Ensuring that the maximum number of volumes per node is not overstepped is the API's responsability, hence we remove the limitation in the CSI.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Integration tests OK


