### PR TITLE
controller: accept size fields in GiB

### DIFF
--- a/.github/workflows/integ-tests.yml
+++ b/.github/workflows/integ-tests.yml
@@ -41,6 +41,7 @@ jobs:
         run: |
           cd internal/integ/ && go test \
             -v \
+            -timeout 20m \
             --create-cluster \
             --create-csi-secret \
             --tear-down-csi \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * document and minimize IAM rule policy for CSI #19 
 * integ-tests: use egoscale v3 #20 
 * integ-test: verify that retain policy is respected #22 
+* controller: accept size fields in GiB #26 
 
 ## 0.29.2
 

--- a/doc/examples/pvc.yaml
+++ b/doc/examples/pvc.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: my-sbs-pvc
+  name: invalid-pvc
   namespace: awesome
 spec:
   accessModes:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 200Gi
+      storage: 200703Mi
   storageClassName: exoscale-sbs

--- a/doc/examples/pvc.yaml
+++ b/doc/examples/pvc.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: invalid-pvc
+  name: my-sbs-pvc
   namespace: awesome
 spec:
   accessModes:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 200703Mi
+      storage: 200Gi
   storageClassName: exoscale-sbs

--- a/driver/controller.go
+++ b/driver/controller.go
@@ -161,7 +161,16 @@ func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 
 	var sizeInGiB int64 = DefaultVolumeSizeGiB
 	if req.GetCapacityRange() != nil {
-		sizeInGiB = convertBytesToGiB(req.GetCapacityRange().RequiredBytes)
+		requiredBytes := req.GetCapacityRange().RequiredBytes
+		if requiredBytes%GiB != 0 {
+			msg := fmt.Sprintf("requested size in bytes cannot be exactly converted to GiB: %d", requiredBytes)
+
+			klog.Error(msg)
+
+			return nil, fmt.Errorf(msg)
+		}
+
+		sizeInGiB = convertBytesToGiB(requiredBytes)
 	}
 
 	request := v3.CreateBlockStorageVolumeRequest{

--- a/driver/controller.go
+++ b/driver/controller.go
@@ -161,7 +161,7 @@ func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 
 	var sizeInGiB int64 = DefaultVolumeSizeGiB
 	if req.GetCapacityRange() != nil {
-		sizeInGiB = req.GetCapacityRange().RequiredBytes
+		sizeInGiB = convertBytesToGiB(req.GetCapacityRange().RequiredBytes)
 	}
 
 	request := v3.CreateBlockStorageVolumeRequest{

--- a/driver/controller.go
+++ b/driver/controller.go
@@ -558,7 +558,7 @@ func (d *controllerService) CreateSnapshot(ctx context.Context, req *csi.CreateS
 		return nil, err
 	}
 
-	klog.Infof("successfully created snapshot %q of size %d GB from volume %q", snapshot.ID, volume.Size, volume.ID)
+	klog.Infof("successfully created snapshot %q of size %d GiB from volume %q", snapshot.ID, volume.Size, volume.ID)
 
 	return &csi.CreateSnapshotResponse{
 		Snapshot: &csi.Snapshot{

--- a/driver/controller.go
+++ b/driver/controller.go
@@ -73,7 +73,7 @@ var (
 )
 
 const (
-	MinimalVolumeSizeBytes = 100 * 1024 * 1024 * 1024
+	DefaultVolumeSizeGiB = 100
 )
 
 type controllerService struct {
@@ -116,9 +116,8 @@ func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 		if v.Name == req.Name {
 			return &csi.CreateVolumeResponse{
 				Volume: &csi.Volume{
-					VolumeId: exoscaleID(zoneName, v.ID),
-					// API reply in bytes then send it without conversion
-					CapacityBytes:      v.Size,
+					VolumeId:           exoscaleID(zoneName, v.ID),
+					CapacityBytes:      convertGiBToBytes(v.Size),
 					AccessibleTopology: newZoneTopology(zoneName),
 				},
 			}, nil
@@ -160,14 +159,14 @@ func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 		klog.Infof("creating volume from snapshot %q", snapshotTarget.ID.String())
 	}
 
-	var sizeInBytes int64 = MinimalVolumeSizeBytes
+	var sizeInGiB int64 = DefaultVolumeSizeGiB
 	if req.GetCapacityRange() != nil {
-		sizeInBytes = req.GetCapacityRange().RequiredBytes
+		sizeInGiB = req.GetCapacityRange().RequiredBytes
 	}
 
 	request := v3.CreateBlockStorageVolumeRequest{
 		Name:                 req.Name,
-		Size:                 convertBytesToGibiBytes(sizeInBytes),
+		Size:                 sizeInGiB,
 		BlockStorageSnapshot: snapshotTarget,
 	}
 
@@ -190,7 +189,7 @@ func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 	return &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{
 			VolumeId:           exoscaleID(zoneName, opDone.Reference.ID),
-			CapacityBytes:      sizeInBytes,
+			CapacityBytes:      convertGiBToBytes(sizeInGiB),
 			AccessibleTopology: newZoneTopology(zoneName),
 			ContentSource:      req.GetVolumeContentSource(),
 		},
@@ -429,9 +428,8 @@ func (d *controllerService) ListVolumes(ctx context.Context, req *csi.ListVolume
 
 			volumesEntries = append(volumesEntries, &csi.ListVolumesResponse_Entry{
 				Volume: &csi.Volume{
-					VolumeId: exoscaleID(zone.Name, v.ID),
-					// API reply in bytes then send it without conversion
-					CapacityBytes:      v.Size,
+					VolumeId:           exoscaleID(zone.Name, v.ID),
+					CapacityBytes:      convertGiBToBytes(v.Size),
 					AccessibleTopology: newZoneTopology(zone.Name),
 				},
 				Status: &csi.ListVolumesResponse_VolumeStatus{
@@ -521,7 +519,7 @@ func (d *controllerService) CreateSnapshot(ctx context.Context, req *csi.CreateS
 					SourceVolumeId: exoscaleID(zoneName, volume.ID),
 					CreationTime:   timestamppb.New(snapshot.CreatedAT),
 					ReadyToUse:     true,
-					SizeBytes:      volume.Size,
+					// We leave the optional SizeBytes field unset as the size of a block storage snapshot is the size of the difference to the volume or previous snapshots, k8s however expects the size to be the size of the restored volume.
 				},
 			}, nil
 		}
@@ -551,7 +549,7 @@ func (d *controllerService) CreateSnapshot(ctx context.Context, req *csi.CreateS
 		return nil, err
 	}
 
-	klog.Infof("successfully created snapshot %q of size %d from volume %q", snapshot.ID, volume.Size, volume.ID)
+	klog.Infof("successfully created snapshot %q of size %d GB from volume %q", snapshot.ID, volume.Size, volume.ID)
 
 	return &csi.CreateSnapshotResponse{
 		Snapshot: &csi.Snapshot{
@@ -559,7 +557,7 @@ func (d *controllerService) CreateSnapshot(ctx context.Context, req *csi.CreateS
 			SourceVolumeId: exoscaleID(zoneName, volume.ID),
 			CreationTime:   timestamppb.New(snapshot.CreatedAT),
 			ReadyToUse:     true,
-			SizeBytes:      volume.Size,
+			// We leave the optional SizeBytes field unset as the size of a block storage snapshot is the size of the difference to the volume or previous snapshots, k8s however expects the size to be the size of the restored volume.
 		},
 	}, nil
 }
@@ -636,7 +634,7 @@ func (d *controllerService) ListSnapshots(ctx context.Context, req *csi.ListSnap
 					SnapshotId:     exoscaleID(zone.Name, s.ID),
 					CreationTime:   timestamppb.New(s.CreatedAT),
 					ReadyToUse:     true,
-					SizeBytes:      s.Size,
+					// We leave the optional SizeBytes field unset as the size of a block storage snapshot is the size of the difference to the volume or previous snapshots, k8s however expects the size to be the size of the restored volume.
 				},
 			})
 		}
@@ -703,9 +701,8 @@ func (d *controllerService) ControllerGetVolume(ctx context.Context, req *csi.Co
 
 	return &csi.ControllerGetVolumeResponse{
 		Volume: &csi.Volume{
-			VolumeId: exoscaleID(zoneName, volume.ID),
-			// API reply in bytes then send it without conversion
-			CapacityBytes: volume.Size,
+			VolumeId:      exoscaleID(zoneName, volume.ID),
+			CapacityBytes: convertGiBToBytes(volume.Size),
 		},
 		Status: &csi.ControllerGetVolumeResponse_VolumeStatus{
 			PublishedNodeIds: instancesID,

--- a/driver/helpers.go
+++ b/driver/helpers.go
@@ -89,6 +89,10 @@ func createMountPoint(path string, file bool) error {
 	return nil
 }
 
+func convertBytesToGiB(sizeInBytes int64) int64 {
+	return sizeInBytes / GiB
+}
+
 func convertGiBToBytes(sizeInGiB int64) int64 {
 	return sizeInGiB * GiB
 }

--- a/driver/helpers.go
+++ b/driver/helpers.go
@@ -12,6 +12,10 @@ import (
 	v3 "github.com/exoscale/egoscale/v3"
 )
 
+const (
+	GiB = 1024 * 1024 * 1024
+)
+
 func exoscaleID(zoneName v3.ZoneName, id v3.UUID) string {
 	return fmt.Sprintf("%s/%s", zoneName, id)
 }
@@ -85,8 +89,8 @@ func createMountPoint(path string, file bool) error {
 	return nil
 }
 
-func convertBytesToGibiBytes(nBytes int64) int64 {
-	return nBytes / (1024 * 1024 * 1024)
+func convertGiBToBytes(sizeInGiB int64) int64 {
+	return sizeInGiB * GiB
 }
 
 func getRequiredZone(requirements *csi.TopologyRequirement, defaultZone v3.ZoneName) (v3.ZoneName, error) {

--- a/internal/integ/integ_test.go
+++ b/internal/integ/integ_test.go
@@ -109,6 +109,12 @@ func TestInvalidVolumeSize(t *testing.T) {
 
 	pvcName := generatePVCName(testName)
 	ns.ApplyPVC(pvcName, "205713Mi", false)
+
+	time.Sleep(3 * time.Second)
+
+	// The volume should not be created as the size is not a value that can be represented exactly in GiB.
+	_, err := ns.K.ClientSet.CoreV1().PersistentVolumeClaims(ns.Name).Get(ns.CTX, pvcName, metav1.GetOptions{})
+	assert.Error(t, err)
 }
 
 var basicDeployment = `

--- a/internal/integ/integ_test.go
+++ b/internal/integ/integ_test.go
@@ -103,20 +103,6 @@ func TestVolumeCreation(t *testing.T) {
 	})
 }
 
-func TestInvalidVolumeSize(t *testing.T) {
-	testName := "invalid-size-vol"
-	ns := k8s.CreateTestNamespace(t, cluster.Get().K8s, testName)
-
-	pvcName := generatePVCName(testName)
-	ns.ApplyPVC(pvcName, "205713Mi", false)
-
-	time.Sleep(3 * time.Second)
-
-	pvc, err := ns.K.ClientSet.CoreV1().PersistentVolumeClaims(ns.Name).Get(ns.CTX, pvcName, metav1.GetOptions{})
-	assert.NoError(t, err)
-	assert.Nil(t, pvc, "The PVC should not be created as the volume size cannot be represented exactly in GiB.")
-}
-
 var basicDeployment = `
 apiVersion: apps/v1
 kind: Deployment

--- a/internal/integ/integ_test.go
+++ b/internal/integ/integ_test.go
@@ -112,9 +112,9 @@ func TestInvalidVolumeSize(t *testing.T) {
 
 	time.Sleep(3 * time.Second)
 
-	// The volume should not be created as the size is not a value that can be represented exactly in GiB.
-	_, err := ns.K.ClientSet.CoreV1().PersistentVolumeClaims(ns.Name).Get(ns.CTX, pvcName, metav1.GetOptions{})
-	assert.Error(t, err)
+	pvc, err := ns.K.ClientSet.CoreV1().PersistentVolumeClaims(ns.Name).Get(ns.CTX, pvcName, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Nil(t, pvc, "The PVC should not be created as the volume size cannot be represented exactly in GiB.")
 }
 
 var basicDeployment = `

--- a/internal/integ/integ_test.go
+++ b/internal/integ/integ_test.go
@@ -93,7 +93,7 @@ func TestVolumeCreation(t *testing.T) {
 	ns := k8s.CreateTestNamespace(t, cluster.Get().K8s, testName)
 
 	pvcName := generatePVCName(testName)
-	ns.ApplyPVC(pvcName, false)
+	ns.ApplyPVC(pvcName, "10Gi", false)
 
 	awaitExpectation(t, "Bound", func() interface{} {
 		pvc, err := ns.K.ClientSet.CoreV1().PersistentVolumeClaims(ns.Name).Get(ns.CTX, pvcName, metav1.GetOptions{})
@@ -101,6 +101,14 @@ func TestVolumeCreation(t *testing.T) {
 
 		return pvc.Status.Phase
 	})
+}
+
+func TestInvalidVolumeSize(t *testing.T) {
+	testName := "invalid-size-vol"
+	ns := k8s.CreateTestNamespace(t, cluster.Get().K8s, testName)
+
+	pvcName := generatePVCName(testName)
+	ns.ApplyPVC(pvcName, "205713Mi", false)
 }
 
 var basicDeployment = `
@@ -135,7 +143,7 @@ func TestVolumeAttach(t *testing.T) {
 	ns := k8s.CreateTestNamespace(t, cluster.Get().K8s, testName)
 
 	pvcName := generatePVCName(testName)
-	ns.ApplyPVC(pvcName, false)
+	ns.ApplyPVC(pvcName, "10Gi", false)
 	ns.Apply(fmt.Sprintf(basicDeployment, pvcName))
 
 	awaitExpectation(t, "Bound", func() interface{} {
@@ -172,7 +180,7 @@ func TestDeleteVolume(t *testing.T) {
 			} else {
 				pvcName = generatePVCName(testName)
 			}
-			ns.ApplyPVC(pvcName, useRetainStorageClass)
+			ns.ApplyPVC(pvcName, "10Gi", useRetainStorageClass)
 
 			pvcClient := ns.K.ClientSet.CoreV1().PersistentVolumeClaims(ns.Name)
 
@@ -276,7 +284,7 @@ func TestSnapshot(t *testing.T) {
 	ns := k8s.CreateTestNamespace(t, cluster.Get().K8s, testName)
 
 	pvcName := generatePVCName(testName)
-	ns.ApplyPVC(pvcName, false)
+	ns.ApplyPVC(pvcName, "10Gi", false)
 
 	pvcClient := ns.K.ClientSet.CoreV1().PersistentVolumeClaims(ns.Name)
 

--- a/internal/integ/k8s/namespace.go
+++ b/internal/integ/k8s/namespace.go
@@ -29,6 +29,7 @@ type Namespace struct {
 type PVC struct {
 	Name             string
 	StorageClassName string
+	Size             string
 }
 
 var pvcTemplate = `
@@ -41,10 +42,10 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 10Gi
+      storage: {{ .Size }}
   storageClassName: {{ .StorageClassName }}`
 
-func (ns *Namespace) ApplyPVC(name string, useStorageClassRetain bool) {
+func (ns *Namespace) ApplyPVC(name string, size string, useStorageClassRetain bool) {
 	tmpl := template.New("volumeTemplate")
 	parsedTmpl, err := tmpl.Parse(pvcTemplate)
 	if err != nil {
@@ -56,6 +57,7 @@ func (ns *Namespace) ApplyPVC(name string, useStorageClassRetain bool) {
 	data := PVC{
 		Name:             name,
 		StorageClassName: "exoscale-sbs",
+		Size:             size,
 	}
 
 	if useStorageClassRetain {


### PR DESCRIPTION
# Description
The block storage related API calls have changed and now return the sizes of volumes and snapshots in GiB instead of bytes. We adapt the controller to this change. Old versions have been verified to work correctly with the new API.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Integration tests OK

