### PR TITLE
goreleaser: set correct ldflags

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,7 +9,7 @@ builds:
   - -mod=vendor
   - -trimpath
   ldflags:
-  - -s -w -X {{.Env.GO_PKG}}/exoscale.version={{.Version}} -X {{.Env.GO_PKG}}/exoscale.commit={{.ShortCommit}}
+  - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
   goos:
   - linux
   goarch:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+* goreleaser: set correct ldflags #29 
+
 ## 0.29.5
 
 ### Improvements


### PR DESCRIPTION
# Description
Previous releases created with goreleaser didn't have the correct buildinfo set
```
❯ docker run exoscale/csi-driver -version
{DriverVersion:dirty GitCommit: BuildDate: GoVersion:go1.22.2 Compiler:gc Platform:linux/amd64}
```

Builds done with make aren't affected.

This PR fixes this.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Integration tests OK

## Testing

```shell
❯ goreleaser release --skip-publish --skip-sign --clean --skip-validate

❯ docker run exoscale/csi-driver -version
{DriverVersion:0.29.5 GitCommit:047b98c BuildDate: GoVersion:go1.22.2 Compiler:gc Platform:linux/amd64}⏎                                                                    

❯ ./dist/exoscale-csi-driver_linux_amd64_v1/exoscale-csi-driver -version
{DriverVersion:0.29.5 GitCommit:047b98c BuildDate: GoVersion:go1.22.2 Compiler:gc Platform:linux/amd64}⏎                                                                    
```

