### PR TITLE
go.mk: lint with staticcheck

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,8 @@ jobs:
 
       - run: make go.mk
 
+      - uses: ./go.mk/.github/actions/setup
+
       - uses: ./go.mk/.github/actions/pre-check
 
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,17 @@ on:
     - 'v**' # Don't run CI tests on release tags
 
 jobs:
+  pre-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - run: make go.mk
+
+      - uses: ./go.mk/.github/actions/pre-check
+
   build:
     runs-on: ubuntu-latest
     steps:
@@ -18,9 +29,6 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/build
-
-      - name: lint
-        run: make lint
 
   docker-build:
     needs: build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,9 @@ jobs:
 
       - uses: ./.github/actions/build
 
+      - name: lint
+        run: make lint
+
   docker-build:
     needs: build
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * goreleaser: set correct ldflags #29 
 * CSI: remove the beta notice #31 
+* go.mk: lint with staticcheck #30 
 
 ## 0.29.5
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ EXTRA_ARGS := -parallel 3 -count=1 -failfast
 # Dependencies
 
 # Requires: https://github.com/exoscale/go.mk
-GO_MK_REF := philippsauter/sc-95507/public-tooling-switch-golanci-lint-staticcheck
+GO_MK_REF := v2.0.0
 
 # make go.mk a dependency for all targets
 .EXTRA_PREREQS = go.mk

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ EXTRA_ARGS := -parallel 3 -count=1 -failfast
 # Dependencies
 
 # Requires: https://github.com/exoscale/go.mk
-GO_MK_REF := v1.0.0
+GO_MK_REF := philippsauter/sc-95507/public-tooling-switch-golanci-lint-staticcheck
 
 # make go.mk a dependency for all targets
 .EXTRA_PREREQS = go.mk


### PR DESCRIPTION
# Description

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Integration tests OK

## Testing
```shell
❯ make lint
go.mk/version.mk:13: warning: overriding recipe for target 'get-version-tag'
/home/sauterp/src/github.com/exoscale/exoscale-csi-driver/go.mk/version.mk:13: warning: ignoring old recipe for target 'get-version-tag'
remote: Enumerating objects: 10, done.
remote: Counting objects: 100% (10/10), done.
remote: Compressing objects: 100% (8/8), done.
remote: Total 10 (delta 3), reused 6 (delta 2), pack-reused 0
Unpacking objects: 100% (10/10), 6.38 KiB | 594.00 KiB/s, done.
From github.com:exoscale/go.mk
   1ecccbf..c320e5b  master     -> origin/master
 * [new tag]         v2.0.0     -> v2.0.0
go.mk/version.mk:13: warning: overriding recipe for target 'get-version-tag'
/home/sauterp/src/github.com/exoscale/exoscale-csi-driver/go.mk/version.mk:13: warning: ignoring old recipe for target 'get-version-tag'
'/home/sauterp/bin/go' install honnef.co/go/tools/cmd/staticcheck@2023.1.7
'/home/sauterp/go/bin/staticcheck' \
   \
  ./...
```

