### PR TITLE
typo in json IAM Role example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Exoscale Block Storage Container Storage Interface Driver.
         {
           "expression": "operation in ['list-zones', 'get-block-storage-volume', 'list-block-storage-volumes', 'create-block-storage-volume', 'delete-block-storage-volume', 'attach-block-storage-volume-to-instance', 'detach-block-storage-volume', 'update-block-storage-volume-labels', 'resize-block-storage-volume', 'get-block-storage-snapshot', 'list-block-storage-snapshots', 'create-block-storage-snapshot', 'delete-block-storage-snapshot']",
           "action": "allow"
-        },
+        }
       ]
     }
   }


### PR DESCRIPTION
typo in the JSON example for the IAM Role
