### PR TITLE
CI: action to manually destroy integ test cluster

### DIFF
--- a/.github/workflows/destroy-integ-test-cluster.yaml
+++ b/.github/workflows/destroy-integ-test-cluster.yaml
@@ -2,6 +2,9 @@ name: destroy-integ-test-cluster
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - philippsauter/gh-action-delete-test-cluster
 
 jobs:
   destroy-integ-test-cluster:

--- a/.github/workflows/destroy-integ-test-cluster.yaml
+++ b/.github/workflows/destroy-integ-test-cluster.yaml
@@ -1,0 +1,24 @@
+name: destroy-integ-test-cluster
+
+on:
+  workflow_dispatch:
+
+jobs:
+  destroy-integ-test-cluster:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Tag Docker Image
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/exoscale/cli/master/install-latest.sh | sh
+
+      - name: run integ tests
+        run: |
+          exo compute sks delete \
+            -n \
+            -f csi-pr-integ-test \
+            -z ch-gva-2
+        shell: bash
+        env:
+          EXOSCALE_API_KEY: ${{ secrets.EXOSCALE_API_KEY_IAMV3 }}
+          EXOSCALE_API_SECRET: ${{ secrets.EXOSCALE_API_SECRET_IAMV3 }}

--- a/.github/workflows/destroy-integ-test-cluster.yaml
+++ b/.github/workflows/destroy-integ-test-cluster.yaml
@@ -2,9 +2,6 @@ name: destroy-integ-test-cluster
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - philippsauter/gh-action-delete-test-cluster
 
 jobs:
   destroy-integ-test-cluster:

--- a/.github/workflows/destroy-integ-test-cluster.yaml
+++ b/.github/workflows/destroy-integ-test-cluster.yaml
@@ -2,23 +2,25 @@ name: destroy-integ-test-cluster
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - philippsauter/gh-action-delete-test-cluster
 
 jobs:
   destroy-integ-test-cluster:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Tag Docker Image
+      - name: Install exo CLI
         run: |
           curl -fsSL https://raw.githubusercontent.com/exoscale/cli/master/install-latest.sh | sh
 
-      - name: run integ tests
+      - name: delete the integ test cluster
         run: |
           exo compute sks delete \
             -n \
             -f csi-pr-integ-test \
             -z ch-gva-2
-        shell: bash
         env:
           EXOSCALE_API_KEY: ${{ secrets.EXOSCALE_API_KEY_IAMV3 }}
           EXOSCALE_API_SECRET: ${{ secrets.EXOSCALE_API_SECRET_IAMV3 }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * Deployment: Add node toleration exist #46
 * doc: warn against manually modifying volumes through Exoscale API #44 
+* CI: action to manually destroy integ test cluster #41 
 
 ## 0.31.0
 


### PR DESCRIPTION
# Description
Sometimes the cluster we use for integration testing can get into a bad state and integration tests fail. This action allows you to delete the test cluster from the GitHub UI. As you can see in this PR the integration tests succeeded again afterwards. (The cluster is recreated automatically on the next run.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Integration tests OK

## Testing

ran successfully:
https://github.com/exoscale/exoscale-csi-driver/actions/runs/12672839655/job/35317769001?pr=41

