### PR TITLE
Deployment: Fix stuck released/terminating volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Deployment: Resolved an issue where volumes could become stuck in a Terminating or Released state, ensuring proper deletion and cleanup
+
 ### Improvements
 
 * Deployment: Add node toleration exist #46

--- a/deployment/0.29.6/controller-rbac.yaml
+++ b/deployment/0.29.6/controller-rbac.yaml
@@ -57,7 +57,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
-    verbs: ["get", "watch", "list", "update", "patch"]
+    verbs: ["get", "watch", "list", "update", "patch", "delete"]
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "watch", "list"]
@@ -88,7 +88,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes", "persistentvolumeclaims", "events"]
-    verbs: ["get", "watch", "list", "create", "update", "patch"]
+    verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]
     verbs: ["get", "watch", "list"]
@@ -122,7 +122,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes", "persistentvolumeclaims", "persistentvolumeclaims/status"]
-    verbs: ["get", "watch", "list", "create", "update", "patch"]
+    verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
   - apiGroups: [""]
     resources: ["pods", "events"]
     verbs: ["get", "watch", "list"]

--- a/deployment/0.31.0/controller-rbac.yaml
+++ b/deployment/0.31.0/controller-rbac.yaml
@@ -57,7 +57,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
-    verbs: ["get", "watch", "list", "update", "patch"]
+    verbs: ["get", "watch", "list", "update", "patch", "delete"]
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "watch", "list"]
@@ -88,7 +88,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes", "persistentvolumeclaims", "events"]
-    verbs: ["get", "watch", "list", "create", "update", "patch"]
+    verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]
     verbs: ["get", "watch", "list"]
@@ -122,7 +122,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes", "persistentvolumeclaims", "persistentvolumeclaims/status"]
-    verbs: ["get", "watch", "list", "create", "update", "patch"]
+    verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
   - apiGroups: [""]
     resources: ["pods", "events"]
     verbs: ["get", "watch", "list"]

--- a/deployment/latest/controller-rbac.yaml
+++ b/deployment/latest/controller-rbac.yaml
@@ -57,7 +57,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
-    verbs: ["get", "watch", "list", "update", "patch"]
+    verbs: ["get", "watch", "list", "update", "patch", "delete"]
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "watch", "list"]
@@ -88,7 +88,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes", "persistentvolumeclaims", "events"]
-    verbs: ["get", "watch", "list", "create", "update", "patch"]
+    verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]
     verbs: ["get", "watch", "list"]
@@ -122,7 +122,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes", "persistentvolumeclaims", "persistentvolumeclaims/status"]
-    verbs: ["get", "watch", "list", "create", "update", "patch"]
+    verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
   - apiGroups: [""]
     resources: ["pods", "events"]
     verbs: ["get", "watch", "list"]


### PR DESCRIPTION
# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

Volumes wouldn't delete automatically with `ReclaimPolicy: Delete` or manually, resulting in them being stuck in a `Terminating` or `Released` state. This produced 404 errors in the Exoscale audit log for the delete volume endpoint.


I added in my local branch some more logging and verified that this code branch works as expected: https://github.com/exoscale/exoscale-csi-driver/blob/9f6d5e869eb0d068c14d32b7cc65d6c3099eca9c/driver/controller.go#L230
So no API or CSI issue per se.

Then I noticed that the csi-provisioner throws errors:
```
"Failed to delete persistentvolume" PV="pvc-744877a7-23ab-4f27-a49d-147b33552baa" err="persistentvolumes \"pvc-744877a7-23ab-4f27-a49d-147b33552baa\" is forbidden: User \"system:serviceaccount:kube-system:exoscale-csi-controller\" cannot delete resource \"persistentvolumes\" in API group \"\" at the cluster scope"
```

This led to a loop where:

1. Kubernetes calling DeleteVolume
2. CSI telling Kubernetes that it was done successfully 
3. The CSI-Provisioner as next step could not delete the volume from Kubernetes itself (remove its finalizers). Because it had no permission calling the Kubernetes API with DELETE on persistentvolume
4. Kubernetes trys again at step 1, making for each loop a 404 error in the audit logs for the DeleteVolume endpoint

The CSi-Provisioner did not have permission for DELETE, because some ClusterRoles of the ServiceAccount did not include delete leading to possibly undefined behaviour.

Without the fix:
```
❯ kubectl auth can-i delete persistentvolume --as=system:serviceaccount:kube-system:exoscale-csi-controller --all-namespaces
no
```

After the fix:
```
❯ kubectl auth can-i delete persistentvolume --as=system:serviceaccount:kube-system:exoscale-csi-controller --all-namespaces
yes
```

Funnily, after the fix is reverted (even the full serviceaccount and clusterroles deleted), it still says "yes".
The problem is I think that just having multiple `ClusterRole`s and binding it to one `ServiceAccount` **with same resources (i.e. persistentvolumes) but different verbs (i.e. delete)**  is not really documented and creates undefined behaviour.  
The documentation says that for merging ClusterRoles like this one has to use special labels: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles

So the PR here is just a quick fix. Another way fixing it would be to use those labels and aggregate them, or just simply using one ClusterRole.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [ ] Integration tests OK

## Testing

<!--
Describe the tests you did
-->

1. Setting up Deployment with Volume
2. Deleting the Deployment + Volume
  * Volume gets stuck: `kubectl get volume`
3. Applying the fix
  * Volume successfully gone
4. Correct behaviour for all future tries
  