### PR TITLE
Reduce minimum blockstorage size to 1GiB (from 10GiB)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Deployment: Resolved an issue where volumes could become stuck in a Terminating or Released state, ensuring proper deletion and cleanup
+* Reduce minimum blockstorage volume size to 1GB
 
 ### Improvements
 

--- a/driver/controller.go
+++ b/driver/controller.go
@@ -74,7 +74,7 @@ var (
 
 const (
 	DefaultVolumeSizeGiB = 100
-	MinimalVolumeSizeGiB = 10
+	MinimalVolumeSizeGiB = 1
 	MaximumVolumeSizeGiB = 10000
 )
 


### PR DESCRIPTION
# Description
[ch113210]

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [ ] Integration tests OK

## Testing

<!--
Describe the tests you did
-->

