### PR TITLE
integ-tests: improve test stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Deployment: Add node toleration exist #46
 * doc: warn against manually modifying volumes through Exoscale API #44 
 * CI: action to manually destroy integ test cluster #41 
+* integ-tests: improve test stability #65 
 
 ## 0.31.0
 

--- a/internal/integ/cluster/utils.go
+++ b/internal/integ/cluster/utils.go
@@ -222,11 +222,11 @@ func (c *Cluster) applyCSI(ctx context.Context) error {
 
 func retry(trial func() error, nRetries int, retryInterval time.Duration) error {
 	if nRetries == 0 {
-		nRetries = 10
+		nRetries = 20
 	}
 
 	if retryInterval == 0 {
-		retryInterval = 10 * time.Second
+		retryInterval = 20 * time.Second
 	}
 
 	for i := 0; i < nRetries-1; i++ {

--- a/internal/integ/integ_test.go
+++ b/internal/integ/integ_test.go
@@ -68,7 +68,7 @@ func generatePVCName(testName string) string {
 func awaitExpectation[T any](t *testing.T, expected T, get func() T) {
 	var actual T
 
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 20; i++ {
 		var err error = nil
 
 		actual = func() T {
@@ -81,7 +81,7 @@ func awaitExpectation[T any](t *testing.T, expected T, get func() T) {
 			return get()
 		}()
 
-		time.Sleep(10 * time.Second)
+		time.Sleep(20 * time.Second)
 
 		if err != nil {
 			continue
@@ -406,7 +406,7 @@ func TestSnapshot(t *testing.T) {
 		}
 
 		status, ok := crdInstance.Object["status"].(map[string]interface{})
-		if !assert.True(t, ok) {
+		if !ok {
 			return false
 		}
 
@@ -439,8 +439,9 @@ func TestSnapshot(t *testing.T) {
 
 	awaitExpectation(t, 0, func() int {
 		snapshots, err := snapshotClient.List(ns.CTX, metav1.ListOptions{})
+		assert.NoError(t, err)
+
 		if err != nil {
-			assert.NoError(t, err)
 			return 0
 		}
 


### PR DESCRIPTION
# Description
Integration tests were frequently failing as we weren't waiting long enough for the CSI deployment to become ready and also because we didn't wait enough for PVCs to enter 'bound' state. We also remove an unnecessary assertion.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Integration tests OK

## Testing
I ran the tests successfully in a row locally.

