### PR TITLE
renovate: enable gomodTidy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+
   "extends": [
     "config:recommended"
-  ]
+  ],
+  "postUpdateOptions": ["gomodTidy"]
 }


### PR DESCRIPTION
# Description
Renovate doesn't run `go mod tidy` by default. However we verify that `go mod tidy` has been executed on every PR with a GH Action. Thus we enable it.

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] Integration tests OK
