### PR TITLE
Node: Max volumes per node from organization quota

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Improvements
 
+* Node: Max volumes per node from organization quota #85
 * container-storage-interface: upgrade to v1.11.0 #73
 * egoscale: update to v3.1.9 to allow volumes of minimum size 1GiB #74 
 

--- a/deployment/latest/node-driver.yaml
+++ b/deployment/latest/node-driver.yaml
@@ -29,6 +29,9 @@ spec:
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
+          envFrom:
+            - secretRef:
+                name: exoscale-credentials
           securityContext:
             privileged: true
           ports:

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -79,13 +79,6 @@ func NewDriver(config *DriverConfig) (*Driver, error) {
 		config: config,
 	}
 
-	// Node Mode is not using client API.
-	// Config API credentials are not provided.
-	if config.Mode == NodeMode {
-		driver.nodeService = newNodeService(nodeMeta)
-		return driver, nil
-	}
-
 	var client *v3.Client
 	if config.ZoneEndpoint != "" {
 		client, err = v3.NewClient(config.Credentials,
@@ -108,9 +101,11 @@ func NewDriver(config *DriverConfig) (*Driver, error) {
 	switch config.Mode {
 	case ControllerMode:
 		driver.controllerService = newControllerService(client, nodeMeta)
+	case NodeMode:
+		driver.nodeService = newNodeService(client, nodeMeta)
 	case AllMode:
 		driver.controllerService = newControllerService(client, nodeMeta)
-		driver.nodeService = newNodeService(nodeMeta)
+		driver.nodeService = newNodeService(client, nodeMeta)
 	default:
 		return nil, fmt.Errorf("unknown mode for driver: %s", config.Mode)
 	}


### PR DESCRIPTION
# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

Read the quotas organization limit to set the per node volume attach limit,
`block-storage-volume-attachments` is per instance

@remyrd / @exoscale/vultures  ⚠️  I think SKS deployment will need to be updated since we need secret for node manifest now.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Integration tests OK

## Testing

<!--
Describe the tests you did
-->

