### PR TITLE
Unit tests: update helper driver tests

### DIFF
--- a/driver/helpers_test.go
+++ b/driver/helpers_test.go
@@ -1,6 +1,8 @@
 package driver
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -109,5 +111,62 @@ func TestGetNewVolumeSize(t *testing.T) {
 		res, err := getNewVolumeSize(test.capRange)
 		require.Equal(t, test.err, err)
 		require.Equal(t, test.res, res)
+	}
+}
+
+func TestCreateMountPoint(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	testBench := []struct {
+		name        string
+		relPath     string
+		file        bool
+		preCreate   bool
+		expectError bool
+		isDir       bool
+	}{
+		{
+			name:    "create directory mount point",
+			relPath: "parent/dir",
+			file:    false,
+			isDir:   true,
+		},
+		{
+			name:    "create file mount point",
+			relPath: "parent/file.txt",
+			file:    true,
+			isDir:   false,
+		},
+		{
+			name:      "existing path no error",
+			relPath:   "parent",
+			file:      false,
+			preCreate: true,
+			isDir:     true,
+		},
+	}
+
+	for _, test := range testBench {
+		t.Run(test.name, func(t *testing.T) {
+			fullPath := filepath.Join(tmpDir, test.relPath)
+
+			if test.preCreate {
+				err := os.MkdirAll(fullPath, 0755)
+				require.NoError(t, err)
+			}
+
+			err := createMountPoint(fullPath, test.file)
+
+			if test.expectError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			info, err := os.Stat(fullPath)
+			require.NoError(t, err)
+			require.Equal(t, test.isDir, info.IsDir())
+		})
 	}
 }


### PR DESCRIPTION
# Description
Update with adding tests for `createMountPoint` helper driver func

As I was exploring codebase and how CSI works internally, I add small PR for tests.

There we test 3 different scenarios when creating mount point: 

 - That a directory is created at the given path, tests behavior when setting up a mount directory
 - That a file is created, and its parent dirs are made if needed, example would be loopback devices or volume files
 - That re-calling the function on an already-existing path does not fail

@Fumesover  please take a look when you have time and you think this is even useful ;) 😄 

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] Integration tests OK

## Testing
Added tests for  `createMountPoint`
