### PR TITLE
integ-test: increase the timeout

### DIFF
--- a/.github/workflows/integ-tests.yml
+++ b/.github/workflows/integ-tests.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           cd internal/integ/ && go test \
             -v \
-            -timeout 20m \
+            -timeout 30m \
             --create-cluster \
             --create-csi-secret \
             --tear-down-csi \


### PR DESCRIPTION
# Description
The integration tests are consistently failing and seem to need more time to run, so we increase the timout.

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [x] Integration tests OK

## Testing

<!--
Describe the tests you did
-->

