### PR TITLE
fix(manifests): update safe dependencies in latest manifests and enable renovate

### DIFF
--- a/deployment/0.33.1/node-driver.yaml
+++ b/deployment/0.33.1/node-driver.yaml
@@ -70,7 +70,7 @@ spec:
               exec:
                 command: ["/exoscale-csi-driver", "pre-stop-hook"]
         - name: csi-node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
           args:
             - "--v=2"
             - "--csi-address=$(CSI_ADDRESS)"
@@ -97,7 +97,7 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: liveness-probe
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.11.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
           args:
             - "--csi-address=$(CSI_ADDRESS)"
           env:

--- a/deployment/0.33.2/node-driver.yaml
+++ b/deployment/0.33.2/node-driver.yaml
@@ -70,7 +70,7 @@ spec:
               exec:
                 command: ["/exoscale-csi-driver", "pre-stop-hook"]
         - name: csi-node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
           args:
             - "--v=2"
             - "--csi-address=$(CSI_ADDRESS)"
@@ -97,7 +97,7 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: liveness-probe
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.11.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
           args:
             - "--csi-address=$(CSI_ADDRESS)"
           env:

--- a/deployment/latest/node-driver.yaml
+++ b/deployment/latest/node-driver.yaml
@@ -70,7 +70,7 @@ spec:
               exec:
                 command: ["/exoscale-csi-driver", "pre-stop-hook"]
         - name: csi-node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
           args:
             - "--v=2"
             - "--csi-address=$(CSI_ADDRESS)"
@@ -97,7 +97,7 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: liveness-probe
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.11.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
           args:
             - "--csi-address=$(CSI_ADDRESS)"
           env:

--- a/renovate.json
+++ b/renovate.json
@@ -16,10 +16,26 @@
       "matchPackageNames": [
         "k8s.io/{/,}**"
       ]
+    },
+    {
+      "description": "Group CSI manifests updates together",
+      "groupName": "CSI manifests",
+      "matchManagers": [
+        "kubernetes"
+      ],
+      "matchFileNames": [
+        "deployment/**"
+      ]
     }
   ],
   "gomod": {
     "enabled": true
+  },
+  "kubernetes": {
+    "enabled": true,
+    "fileMatch": [
+      "(^|/)deployment/latest/.+\\.ya?ml$"
+    ]
   },
   "postUpdateOptions": [
     "gomodTidy",


### PR DESCRIPTION
# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

* Bump safe version (regarding change) in latest manifests
* Enable renovate on latest manifests 

Regarding one customer ticket, i think we are hit by this issue, solved in 2.13 https://github.com/kubernetes-csi/node-driver-registrar/pull/426

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] Integration tests OK

## Testing

<!--
Describe the tests you did
-->

