### PR TITLE
ci: add pull_request trigger to CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,9 @@ on:
     - '**.md'
     tags-ignore:
     - 'v**' # Don't run CI tests on release tags
+  pull_request:
+    branches:
+    - main
 
 jobs:
   pre-check:


### PR DESCRIPTION
# Description

ci: add pull_request trigger so CI runs on fork pull requests

Currently the workflow only triggers on `push`, so fork PRs show no CI status.

Before:
```yaml
on:
  push:
    branches:
    - '**'
```

After:
```yaml
on:
  push:
    branches:
    - '**'
  pull_request:
    branches:
    - main
```

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] Integration tests OK

## Testing

CI should run on this PR and show status checks.