### PR TITLE
driver: fix CCM zone metadata lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+* fix(driver): correctly look up zone metadata from node CCM
+
 ## v0.34.0
 * fix(manifests): update safe dependencies in latest manifests and enable renovate #146
 

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -216,7 +216,7 @@ func getExoscaleNodeMetadataFromCCM() (*nodeMetadata, error) {
 		return nil, fmt.Errorf("failed to get nodes: %w", err)
 	}
 
-	region, ok := node.Labels["topology.kubernetes.io/region"]
+	zone, ok := node.Labels["topology.kubernetes.io/zone"]
 	if !ok {
 		return nil, fmt.Errorf("no zone found on node, missing Exoscale CCM")
 	}
@@ -231,7 +231,7 @@ func getExoscaleNodeMetadataFromCCM() (*nodeMetadata, error) {
 	}
 
 	return &nodeMetadata{
-		zoneName:   v3.ZoneName(region),
+		zoneName:   v3.ZoneName(zone),
 		InstanceID: instanceID,
 	}, nil
 }


### PR DESCRIPTION
# Description

Exoscale CCM metadata provides `topology.kubernetes.io/zone` and not `topology.kubernetes.io/region`.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Integration tests OK

## Testing

<!--
Describe the tests you did
-->

